### PR TITLE
refactor: remove guzzle explicit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.1.3",
         "ext-json": "*",
         "league/oauth2-client": "^2.4",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": ">=6.3",
         "jms/serializer": "^1.13||^3.13",
         "psr/log": "^1.1"
     },


### PR DESCRIPTION
refactor: remove guzzle explicit version dependency to simplify php8.1 and symfony 5.4 future updates